### PR TITLE
Primary Title for Head of Faith

### DIFF
--- a/gui/window_faith.gui
+++ b/gui/window_faith.gui
@@ -735,6 +735,8 @@ window = {
 								expand = {}
 							}
 
+							PTHF_override_primary_title_checkbox = {}
+
 							expand = {}
 
 						}


### PR DESCRIPTION
Added `PTHF_override_primary_title_checkbox` invocation to `window_faith.gui`.

Resolves #24.